### PR TITLE
Bump version to 1.0.3

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -2,7 +2,7 @@ numpy:
 - '1.9'
 pin_run_as_build:
   python:
-    max_pin: x.x
     min_pin: x.x
+    max_pin: x.x
 python:
 - '2.7'

--- a/.circleci/run_docker_build.sh
+++ b/.circleci/run_docker_build.sh
@@ -29,7 +29,7 @@ if [ -z "$CONFIG" ]; then
     exit 1
 fi
 
-test -d "$ARTIFACTS" || mkdir "$ARTIFACTS"
+mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
 rm -f "$DONE_CANARY"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "array2gif" %}
-{% set version = "1.0.0" %}
-{% set sha256 = "d8c9ca4b7656f4016c578e6b0f87daf47114f5456db2fceece896be5d173e9f0" %}
+{% set version = "1.0.3" %}
+{% set sha256 = "bda921f71366246e08235131aefa9b6272c168d886babae71ed4509be884c370" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/tanyaschlusser/{{ name }}/archive/v{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   noarch: python
+  noarch: python
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
 


### PR DESCRIPTION
Version 1.0.3 adds a bugfix from @femto113 where the width and height of the gif were swapped.

Automation:
@conda-forge-admin, please add noarch: python
@conda-forge-admin, please rerender

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Reset the build number to `0` (if the version changed)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes tanyaschlusser/array2gif#2
<!--
Please add any other relevant info below:
-->
